### PR TITLE
Fix shield not updating with max life buffs

### DIFF
--- a/ShieldMod/Players/MyModPlayer.cs
+++ b/ShieldMod/Players/MyModPlayer.cs
@@ -51,6 +51,13 @@ namespace ShieldMod.Players
 
         public override void PostUpdate()
         {
+            // Recalculate shield capacity after all effects such as buffs
+            // modify the player's maximum life. This ensures buffs like
+            // Lifeforce potions properly update the shield.
+            maxShield = Player.statLifeMax2;
+            if (shield > maxShield)
+                shield = maxShield;
+
             regenTimer++;
             timeSinceLastHit++;
 

--- a/ShieldMod/description.txt
+++ b/ShieldMod/description.txt
@@ -2,4 +2,5 @@
 
 
 This mod introduces a dynamic shield system that absorbs incoming damage before HP is affected. The shield regenerates over time and features custom visuals and sounds.
+Now the shield's maximum capacity updates whenever your max life changes, such as when using Lifeforce potions.
 

--- a/ShieldMod/description_workshop.txt
+++ b/ShieldMod/description_workshop.txt
@@ -2,4 +2,5 @@
 
 
 This mod introduces a dynamic shield system that absorbs incoming damage before HP is affected. The shield regenerates over time and features custom visuals and sounds.
+Now the shield's maximum capacity updates whenever your max life changes, such as when using Lifeforce potions.
 


### PR DESCRIPTION
## Summary
- ensure PostUpdate recalculates `maxShield` based on `Player.statLifeMax2`
- clarify description that shield capacity updates with Lifeforce potion and other max life changes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6889cea52c60832d8fbbfdd50083a9a3