### PR TITLE
Handle shield heal text sync

### DIFF
--- a/ShieldMod/Players/EmergencyAegisPlayer.cs
+++ b/ShieldMod/Players/EmergencyAegisPlayer.cs
@@ -160,7 +160,18 @@ namespace ShieldMod
         {
             if (_healTextSum > 0 && (int)Main.GameUpdateCount > _healTextTick)
             {
-                CombatText.NewText(Player.getRect(), Color.Cyan, $"+{_healTextSum}", true);
+                if (Main.netMode == NetmodeID.Server)
+                {
+                    ModPacket packet = Mod.GetPacket();
+                    packet.Write((byte)ShieldMod.Msg.ShieldHealText);
+                    packet.Write((byte)Player.whoAmI);
+                    packet.Write(_healTextSum);
+                    packet.Send(-1, -1);
+                }
+                else
+                {
+                    CombatText.NewText(Player.getRect(), Color.Cyan, $"+{_healTextSum}", true);
+                }
                 _healTextSum = 0;
             }
         }

--- a/ShieldMod/ShieldMod.cs
+++ b/ShieldMod/ShieldMod.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
@@ -10,7 +11,8 @@ namespace ShieldMod
         internal enum Msg : byte
         {
             SyncPlayerShield,
-            RequestShieldSync
+            RequestShieldSync,
+            ShieldHealText
         }
 
         public override void HandlePacket(BinaryReader reader, int whoAmI)
@@ -54,6 +56,25 @@ namespace ShieldMod
                         Player p = Main.player[i];
                         if (p != null && p.active)
                             p.GetModPlayer<MyModPlayer>().NetSendShield(toWho);
+                    }
+                    break;
+                }
+
+                case Msg.ShieldHealText:
+                {
+                    if (Main.netMode == NetmodeID.Server)
+                        break;
+
+                    byte playerId = reader.ReadByte();
+                    int healAmount = reader.ReadInt32();
+                    if (healAmount <= 0)
+                        break;
+
+                    if (playerId < Main.maxPlayers)
+                    {
+                        Player p = Main.player[playerId];
+                        if (p != null && p.active)
+                            CombatText.NewText(p.getRect(), Color.Cyan, $"+{healAmount}", true);
                     }
                     break;
                 }


### PR DESCRIPTION
## Summary
- add a dedicated packet for shield heal text and broadcast from the server to active clients
- avoid spawning combat text on dedicated servers by using the new packet on clients only

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b0f046ba8832d8d4f44ed5be01124)