### PR TITLE
Adjust absorption sigil regen and penalty

### DIFF
--- a/ShieldMod/Players/AbsorptionSigilPlayer.cs
+++ b/ShieldMod/Players/AbsorptionSigilPlayer.cs
@@ -6,28 +6,28 @@ namespace ShieldMod
 {
     /// <summary>
     /// 흡수의 인장 효과:
-    /// - 입힌 피해량의 4%만큼 보호막 회복 (누적 방식)
+    /// - 입힌 피해량의 3%만큼 보호막 회복 (누적 방식)
     /// - DoT/디버프 피해는 OnHit 콜백이 없으므로 자동 제외
-    /// - 보호막이 0 이하로 '떨어지는 순간'(파괴 순간)부터 흡수량 50% 감소
-    ///   · 기본 5초(300틱)
-    ///   · Emergency Aegis 착용 시 3초(180틱)
+    /// - 보호막이 0 이하로 '떨어지는 순간'(파괴 순간)부터 흡수량 50% 유지(= 1.5%)
+    ///   · 기본 6초(360틱)
+    ///   · Emergency Aegis 착용 시 4초(240틱)
     /// </summary>
     public class AbsorptionSigilPlayer : ModPlayer
     {
         public bool HasAbsorptionSigil;
 
-        // 4% = 4/100 → (damageDone * 4)를 누적해 100마다 1 보호막 회복
-        private int _accumPercent;
+        // 3% = 30/1000 → (damageDone * 30)을 누적해 1000마다 1 보호막 회복
+        private int _accumPermille;
 
         // 보호막 파괴(0 이하로 떨어짐) 순간 감지용
         private int _prevShield;
 
-        // 흡수량 50% 감소 남은 시간(틱)
+        // 흡수량 50% 유지 남은 시간(틱)
         private int _siphonPenaltyTicks;
 
         public override void Initialize()
         {
-            _accumPercent = 0;
+            _accumPermille = 0;
             _prevShield = 0;
             _siphonPenaltyTicks = 0;
         }
@@ -36,7 +36,7 @@ namespace ShieldMod
 
         public override void OnEnterWorld()
         {
-            _accumPercent = 0;
+            _accumPermille = 0;
             _siphonPenaltyTicks = 0;
 
             var mp = Player.GetModPlayer<MyModPlayer>();
@@ -45,7 +45,7 @@ namespace ShieldMod
 
         public override void OnRespawn()
         {
-            _accumPercent = 0;
+            _accumPermille = 0;
             _prevShield = 0;
             _siphonPenaltyTicks = 0;
         }
@@ -62,7 +62,7 @@ namespace ShieldMod
             if (_prevShield > 0 && curShield <= 0)
             {
                 bool hasAegis = Player.GetModPlayer<EmergencyAegisPlayer>()?.HasAegis == true;
-                _siphonPenaltyTicks = hasAegis ? 180 : 300; // 3초 or 5초
+                _siphonPenaltyTicks = hasAegis ? 240 : 360; // 4초 or 6초
             }
 
             _prevShield = curShield;
@@ -93,16 +93,16 @@ namespace ShieldMod
             if (mp == null || mp.maxShield <= 0 || mp.shield >= mp.maxShield)
                 return;
 
-            // 흡수량: 기본 4%, 보호막 파괴 후 패널티 동안 50%(=2%)
-            int percent = (_siphonPenaltyTicks > 0) ? 2 : 4;
+            // 흡수량: 기본 3%, 보호막 파괴 후 패널티 동안 50%(= 1.5%)
+            int permille = (_siphonPenaltyTicks > 0) ? 15 : 30;
 
             // 누적
-            _accumPercent += damageDone * percent;
+            _accumPermille += damageDone * permille;
 
-            int heal = _accumPercent / 100;
+            int heal = _accumPermille / 1000;
             if (heal <= 0) return;
 
-            _accumPercent %= 100;
+            _accumPermille %= 1000;
 
             int before = mp.shield;
             int after = before + heal;
@@ -116,5 +116,7 @@ namespace ShieldMod
             // 텍스트는 Aegis 합산 시스템을 그대로 재사용(다음 프레임 1번만 표시)
             Player.GetModPlayer<EmergencyAegisPlayer>()?.QueueShieldHealText(gained);
         }
+
+        public bool IsSiphonPenaltyActive => _siphonPenaltyTicks > 0;
     }
 }

--- a/ShieldMod/Players/MyModPlayer.cs
+++ b/ShieldMod/Players/MyModPlayer.cs
@@ -120,7 +120,8 @@ namespace ShieldMod
         public override void PostUpdate()
         {
             bool hasAegis = Player.GetModPlayer<EmergencyAegisPlayer>().HasAegis;
-            bool hasAbsorptionSigil = Player.GetModPlayer<AbsorptionSigilPlayer>().HasAbsorptionSigil;
+            var absorption = Player.GetModPlayer<AbsorptionSigilPlayer>();
+            bool hasAbsorptionSigil = absorption.HasAbsorptionSigil;
 
             if (suppressRedDamageTextTicks > 0)
                 suppressRedDamageTextTicks--;
@@ -166,31 +167,26 @@ namespace ShieldMod
             }
 
             // 쿨다운 중에는 자연 재생/보너스 재생 둘 다 정지
+            // ===== 보호막 파괴 페널티 기간 =====
             if (shieldBreakCooldown > 0)
             {
                 shieldBreakCooldown--;
+
+                // 흡수 페널티가 겹칠 때 자연 재생은 더 강하게 억제(피드백: 자연 회복 상한 완화)
+                if (hasAbsorptionSigil && absorption.IsSiphonPenaltyActive && shield < maxShield)
+                {
+                    regenTimer = 0;
+                    timeSinceLastHit = 0;
+                }
+
                 NetMaybeSync();
                 return;
             }
 
-            // ===== 흡수의 인장: '모든 재생' 차단 =====
-            // - 자연 재생 + Emergency Aegis의 기본(+2/s) 재생은 모두 차단
-            // - Absorption(딜 4%)과 Emergency Aegis의 '긴급 HoT'는 별도 시스템이므로 정상 작동
-            if (hasAbsorptionSigil)
-            {
-                // 재생이 완전히 멈춘 상태를 유지(가속도/틱 쌓임 방지)
-                regenTimer = 0;
-                timeSinceLastHit = 0; 
-                               
-                // 토큰 누적/잔여가 남아있으면, 인장 해제 순간에 튀어오르는 것 방지
-                _aegisTickAccum = 0;
-                _aegisPending = 0;
-                NetMaybeSync();
-                return;
-            }
+            float naturalRegenMultiplier = hasAbsorptionSigil ? 0.5f : 1f;
 
             // ===== 기본 자연 재생 로직(원본 유지) =====
-            float regenPerSecond = CalculateNaturalRegenPerSecond();
+            float regenPerSecond = CalculateNaturalRegenPerSecond() * naturalRegenMultiplier;
 
             int interval = (int)(60f / regenPerSecond);
             if (regenPerSecond > 0f && interval > 0 && regenTimer % interval == 0 && shield < maxShield)
@@ -279,13 +275,16 @@ namespace ShieldMod
 
         public (float naturalRegenPerSecond, float aegisRegenPerSecond) GetShieldRegenPerSecond()
         {
-            bool hasAbsorptionSigil = Player.GetModPlayer<AbsorptionSigilPlayer>().HasAbsorptionSigil;
+            var absorption = Player.GetModPlayer<AbsorptionSigilPlayer>();
+            bool hasAbsorptionSigil = absorption.HasAbsorptionSigil;
             bool hasAegis = Player.GetModPlayer<EmergencyAegisPlayer>().HasAegis;
 
-            if (shieldBreakCooldown > 0 || hasAbsorptionSigil || shield >= maxShield)
+            if (shieldBreakCooldown > 0 || shield >= maxShield)
                 return (0f, 0f);
 
             float natural = CalculateNaturalRegenPerSecond();
+            if (hasAbsorptionSigil)
+                natural *= 0.5f;
             float aegis = 0f;
 
             if (hasAegis && Player.statLife > 0 && shield < maxShield)


### PR DESCRIPTION
## Summary
- Keep Absorption Sigil at 3% base siphon but restore break penalty strength to 50% (1.5%) while retaining longer 4–6s duration
- Preserve partial natural regen and Aegis baseline regen while suppressing natural regen buildup during break penalties

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b35037eb0832dbfd5d804dfddaf80)