### PR TITLE
Add shield regen HUD indicator and expose cooldown state

### DIFF
--- a/ShieldMod/MyModSystem.cs
+++ b/ShieldMod/MyModSystem.cs
@@ -17,6 +17,7 @@ namespace ShieldMod
         internal ShieldUI shieldUI;
 
         public static Texture2D PixelTexture;
+        internal static bool RegenHintEnabled = true;
 
         // ■ 커스텀 레시피 그룹 등록 (은/텅스텐, 데모/크림테인)
         public override void AddRecipeGroups()
@@ -44,6 +45,16 @@ namespace ShieldMod
             }
         }
 
+        public override void OnWorldLoad()
+        {
+            RegenHintEnabled = ModContent.GetInstance<ShieldModConfig>().ShowRegenCooldownIndicator;
+        }
+
+        public override void OnWorldUnload()
+        {
+            RegenHintEnabled = true;
+        }
+
         public override void UpdateUI(GameTime gameTime)
         {
             shieldInterface?.Update(gameTime);
@@ -57,6 +68,13 @@ namespace ShieldMod
 
             Player p = Main.LocalPlayer;
             if (p == null || !p.active) return;
+
+            if (ShieldMod.ToggleRegenHintKeybind != null && ShieldMod.ToggleRegenHintKeybind.JustPressed)
+            {
+                RegenHintEnabled = !RegenHintEnabled;
+                string text = RegenHintEnabled ? "Shield regen HUD: ON" : "Shield regen HUD: OFF";
+                Main.NewText(text, new Color(100, 200, 255));
+            }
 
             var mp = p.GetModPlayer<MyModPlayer>();
             if (mp == null || mp.suppressRedDamageTextTicks <= 0) return;

--- a/ShieldMod/Players/MyModPlayer.cs
+++ b/ShieldMod/Players/MyModPlayer.cs
@@ -29,6 +29,8 @@ namespace ShieldMod
         // 편의 프로퍼티
         public int CurrentShield => shield;
         public int MaxShield => maxShield;
+        public int ShieldBreakCooldownTicks => shieldBreakCooldown;
+        public int TimeSinceLastHitTicks => timeSinceLastHit;
         public int HitEffectTimer => hitEffectTimer;
 
         // 외부(선흡수 등)에서 안전하게 호출할 수 있는 유틸(리플렉션 제거)
@@ -188,28 +190,7 @@ namespace ShieldMod
             }
 
             // ===== 기본 자연 재생 로직(원본 유지) =====
-            float regenPerSecond = 1f;
-            if (timeSinceLastHit >= 300) regenPerSecond = 2f;
-            if (timeSinceLastHit >= 600) regenPerSecond = 3f;
-            if (timeSinceLastHit >= 900) regenPerSecond = 5f;
-            if (timeSinceLastHit >= 1200) regenPerSecond = 8f;
-            if (timeSinceLastHit >= 1800) regenPerSecond = 12f;
-            if (timeSinceLastHit >= 2400) regenPerSecond = 20f;
-
-            regenPerSecond *= 1f + ShieldRegenBonus;
-
-            // 보스전 상한(원본 유지) - LINQ 제거(할당/오버헤드 방지)
-            bool anyBoss = false;
-            for (int i = 0; i < Main.maxNPCs; i++)
-            {
-                NPC n = Main.npc[i];
-                if (n != null && n.active && n.boss) { anyBoss = true; break; }
-            }
-            if (anyBoss)
-            {
-                float bossLimit = 5f * (1f + ShieldRegenBonus);
-                if (regenPerSecond > bossLimit) regenPerSecond = bossLimit;
-            }
+            float regenPerSecond = CalculateNaturalRegenPerSecond();
 
             int interval = (int)(60f / regenPerSecond);
             if (regenPerSecond > 0f && interval > 0 && regenTimer % interval == 0 && shield < maxShield)
@@ -295,7 +276,51 @@ namespace ShieldMod
             if (info.Damage > 0)
                 timeSinceLastHit = 0;
         }
+
+        public (float naturalRegenPerSecond, float aegisRegenPerSecond) GetShieldRegenPerSecond()
+        {
+            bool hasAbsorptionSigil = Player.GetModPlayer<AbsorptionSigilPlayer>().HasAbsorptionSigil;
+            bool hasAegis = Player.GetModPlayer<EmergencyAegisPlayer>().HasAegis;
+
+            if (shieldBreakCooldown > 0 || hasAbsorptionSigil || shield >= maxShield)
+                return (0f, 0f);
+
+            float natural = CalculateNaturalRegenPerSecond();
+            float aegis = 0f;
+
+            if (hasAegis && Player.statLife > 0 && shield < maxShield)
+                aegis = 2f;
+
+            return (natural, aegis);
+        }
+
+        private float CalculateNaturalRegenPerSecond()
+        {
+            float regenPerSecond = 1f;
+            if (timeSinceLastHit >= 300) regenPerSecond = 2f;
+            if (timeSinceLastHit >= 600) regenPerSecond = 3f;
+            if (timeSinceLastHit >= 900) regenPerSecond = 5f;
+            if (timeSinceLastHit >= 1200) regenPerSecond = 8f;
+            if (timeSinceLastHit >= 1800) regenPerSecond = 12f;
+            if (timeSinceLastHit >= 2400) regenPerSecond = 20f;
+
+            regenPerSecond *= 1f + ShieldRegenBonus;
+
+            // 보스전 상한(원본 유지) - LINQ 제거(할당/오버헤드 방지)
+            bool anyBoss = false;
+            for (int i = 0; i < Main.maxNPCs; i++)
+            {
+                NPC n = Main.npc[i];
+                if (n != null && n.active && n.boss) { anyBoss = true; break; }
+            }
+            if (anyBoss)
+            {
+                float bossLimit = 5f * (1f + ShieldRegenBonus);
+                if (regenPerSecond > bossLimit) regenPerSecond = bossLimit;
+            }
+
+            return regenPerSecond;
+        }
     }
 
 }
-

--- a/ShieldMod/ShieldMod.cs
+++ b/ShieldMod/ShieldMod.cs
@@ -15,6 +15,18 @@ namespace ShieldMod
             ShieldHealText
         }
 
+        public static ModKeybind ToggleRegenHintKeybind;
+
+        public override void Load()
+        {
+            ToggleRegenHintKeybind = KeybindLoader.RegisterKeybind(this, "Toggle Shield Regen HUD", "K");
+        }
+
+        public override void Unload()
+        {
+            ToggleRegenHintKeybind = null;
+        }
+
         public override void HandlePacket(BinaryReader reader, int whoAmI)
         {
             Msg msg = (Msg)reader.ReadByte();

--- a/ShieldMod/ShieldModConfig.cs
+++ b/ShieldMod/ShieldModConfig.cs
@@ -28,6 +28,11 @@ namespace ShieldMod
         [DefaultValue(true)]
         public bool EnableShieldElectricEffect;
 
+        [Label("Show regen/cooldown hint")]
+        [Tooltip("Displays your current shield regeneration tier (1/2/3/5/8/12/20 per second) or break cooldown as a small HUD label.")]
+        [DefaultValue(true)]
+        public bool ShowRegenCooldownIndicator;
+
         [Label("Shield Max Health Ratio")]
         [Tooltip("Set the maximum shield as a percentage of the player's max health (statLifeMax2).\nExample: 1.00 = 100%, 0.25 = 25%")]
         [Range(0.25f, 1f)]

--- a/ShieldMod/UI/ShieldUI.cs
+++ b/ShieldMod/UI/ShieldUI.cs
@@ -74,6 +74,9 @@ namespace ShieldMod.UI
             string text = $"{shield} / {maxShield}";
             Vector2 textPos = new Vector2(position.X + (barWidth / 2f), position.Y + barHeight + 18f);
             Utils.DrawBorderString(spriteBatch, text, textPos, Color.White, 1f, 0.5f, 0.5f);
+
+            Vector2 regenPos = new Vector2(textPos.X, textPos.Y + 16f);
+            DrawRegenAndCooldownInfo(spriteBatch, regenPos, modPlayer, config, alignLeft: false);
         }
 
         /// <summary>
@@ -219,6 +222,9 @@ namespace ShieldMod.UI
             string text = $"{modPlayer.shield} / {modPlayer.maxShield}";
             Vector2 textPos = new Vector2(startPos.X + 16, startPos.Y + iconCount * spacing + 8);
             Utils.DrawBorderString(spriteBatch, text, textPos, Color.White, 1f, 0.5f, 0.5f);
+
+            Vector2 regenPos = new Vector2(textPos.X, textPos.Y + 16f);
+            DrawRegenAndCooldownInfo(spriteBatch, regenPos, modPlayer, config, alignLeft: true);
         }
 
         // =========================
@@ -229,6 +235,46 @@ namespace ShieldMod.UI
             if (v < min) return min;
             if (v > max) return max;
             return v;
+        }
+
+        private void DrawRegenAndCooldownInfo(SpriteBatch spriteBatch, Vector2 anchor, MyModPlayer modPlayer, ShieldModConfig config, bool alignLeft)
+        {
+            if (!config.ShowRegenCooldownIndicator || !MyModSystem.RegenHintEnabled)
+                return;
+
+            int cooldown = modPlayer.ShieldBreakCooldownTicks;
+            (float natural, float aegis) = modPlayer.GetShieldRegenPerSecond();
+
+            string label;
+            Color color;
+
+            if (cooldown > 0)
+            {
+                label = $"Cooldown {FormatSeconds(cooldown)}";
+                color = new Color(250, 140, 110);
+            }
+            else if (natural <= 0f && aegis <= 0f)
+            {
+                label = "Regen paused";
+                color = Color.LightGray;
+            }
+            else
+            {
+                label = $"Regen {natural:0.#}/s";
+                if (aegis > 0f)
+                    label += $" (+{aegis:0.#})";
+
+                float k = MathHelper.Clamp(natural / 12f, 0f, 1f);
+                color = Color.Lerp(new Color(120, 190, 255), new Color(70, 230, 255), k);
+            }
+
+            float scale = 0.85f;
+            Utils.DrawBorderString(spriteBatch, label, anchor, color, scale, alignLeft ? 0f : 0.5f, 0f);
+        }
+
+        private static string FormatSeconds(int ticks)
+        {
+            return $"{(ticks / 60f):0.0}s";
         }
     }
 }


### PR DESCRIPTION
## Summary
- expose shield cooldown and last-hit timers through helper accessors
- display current shield regeneration tier or break cooldown as a small HUD label on both bar and icon styles
- add a config toggle and in-game hotkey to turn the regen/cooldown indicator on or off for a cleaner HUD

## Testing
- dotnet build ShieldMod.sln *(fails: dotnet CLI not available in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b2fd3f7a4832d9df9975caa43c665)