### PR TITLE
Ensure multiplayer shield ratio syncs from server

### DIFF
--- a/ShieldMod/Players/MyModPlayer.cs
+++ b/ShieldMod/Players/MyModPlayer.cs
@@ -63,12 +63,21 @@ namespace ShieldMod
         private int _netLastMax;
         private int _netLastBreakCd;
         private int _netLastTimeSinceHit;
+        private static float _serverShieldMaxRatio = 1f;
+
+        public void SetServerShieldMaxRatio(float ratio)
+        {
+            _serverShieldMaxRatio = MathHelper.Clamp(ratio, 0.25f, 1f);
+        }
 
         private static float GetShieldMaxRatio()
         {
-            // 멀티에서는 서버 설정을 권위로 사용합니다.
+            // 멀티에서는 서버 설정을 권위로 사용합니다. (클라에서도 서버가 내려준 비율을 사용)
             if (Main.netMode == NetmodeID.Server)
                 return MathHelper.Clamp(ModContent.GetInstance<ShieldModServerConfig>().ShieldMaxRatio, 0.25f, 1f);
+
+            if (Main.netMode == NetmodeID.MultiplayerClient)
+                return MathHelper.Clamp(_serverShieldMaxRatio, 0.25f, 1f);
 
             return MathHelper.Clamp(ModContent.GetInstance<ShieldModConfig>().ShieldMaxRatio, 0.25f, 1f);
         }
@@ -151,7 +160,7 @@ namespace ShieldMod
                 // 클라에서 maxShield가 0이라 UI가 완전히 죽는 걸 방지하는 최소 안전장치
                 if (maxShield <= 0)
                 {
-                    float ratio = MathHelper.Clamp(ModContent.GetInstance<ShieldModConfig>().ShieldMaxRatio, 0.25f, 1f);
+                    float ratio = MathHelper.Clamp(_serverShieldMaxRatio > 0f ? _serverShieldMaxRatio : ModContent.GetInstance<ShieldModConfig>().ShieldMaxRatio, 0.25f, 1f);
                     maxShield = (int)(Player.statLifeMax2 * ratio);
                     if (shield > maxShield) shield = maxShield;
                 }
@@ -262,6 +271,7 @@ namespace ShieldMod
             packet.Write(maxShield);
             packet.Write(shieldBreakCooldown);
             packet.Write(timeSinceLastHit);
+            packet.Write(GetShieldMaxRatio());
             packet.Send(toWho, -1);
         }
 

--- a/ShieldMod/ShieldMod.cs
+++ b/ShieldMod/ShieldMod.cs
@@ -29,6 +29,7 @@ namespace ShieldMod
                     int maxShield = reader.ReadInt32();
                     int breakCd = reader.ReadInt32();
                     int timeSinceHit = reader.ReadInt32();
+                    float shieldMaxRatio = reader.ReadSingle();
 
                     if (playerId < Main.maxPlayers)
                     {
@@ -40,6 +41,7 @@ namespace ShieldMod
                             mp.maxShield = maxShield;
                             mp.shieldBreakCooldown = breakCd;
                             mp.timeSinceLastHit = timeSinceHit;
+                            mp.SetServerShieldMaxRatio(shieldMaxRatio);
                         }
                     }
                     break;


### PR DESCRIPTION
## Summary
- sync the maximum shield ratio from the server to clients to keep multiplayer values authoritative
- include the shield ratio in shield sync packets and reuse it for client-side fallbacks

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b56d00034832d8c7ff9eff637846b)