### PR TITLE
Add configurable shield effect colors

### DIFF
--- a/ShieldMod/Layers/ShieldHitEffectLayer.cs
+++ b/ShieldMod/Layers/ShieldHitEffectLayer.cs
@@ -44,11 +44,13 @@ namespace ShieldMod.Layers
             Texture2D tex = _hitTex.Value;
             Vector2 origin = tex.Size() * 0.5f;
 
+            Color hitColor = ModContent.GetInstance<ShieldModConfig>().ShieldHitColor;
+
             drawInfo.DrawDataCache.Add(new DrawData(
                 tex,
                 pos,
                 null,
-                Color.Cyan * alpha,      // Cyan 페이드
+                hitColor * alpha,
                 0f,
                 origin,
                 scale,

--- a/ShieldMod/Localization/en-US_Mods.ShieldMod.hjson
+++ b/ShieldMod/Localization/en-US_Mods.ShieldMod.hjson
@@ -108,6 +108,16 @@ Configs: {
 			Label: Electric effect (bar)
 			Tooltip: Draws an electric/lightning animation inside the filled part of the bar UI.
 		}
+
+		ShieldHitColor: {
+			Label: Shield hit effect color
+			Tooltip: Color used for the shield hit overlay and absorb text (default: blue).
+		}
+
+		ShieldRegenColor: {
+			Label: Shield regen effect color
+			Tooltip: Color used for shield heal text effects.
+		}
 	}
 
 	ShieldUIDisplayStyle: {

--- a/ShieldMod/Players/EmergencyAegisPlayer.cs
+++ b/ShieldMod/Players/EmergencyAegisPlayer.cs
@@ -204,7 +204,8 @@ namespace ShieldMod
                 }
                 else
                 {
-                    CombatText.NewText(Player.getRect(), Color.Cyan, $"+{_healTextSum}", true);
+                    Color regenColor = ModContent.GetInstance<ShieldModConfig>().ShieldRegenColor;
+                    CombatText.NewText(Player.getRect(), regenColor, $"+{_healTextSum}", true);
                 }
                 _healTextSum = 0;
             }

--- a/ShieldMod/Players/ShieldPreAbsorbPlayer.cs
+++ b/ShieldMod/Players/ShieldPreAbsorbPlayer.cs
@@ -107,7 +107,10 @@ namespace ShieldMod
             SpawnShieldImpactDust(_queuedAbsorb, _queuedStrong);
 
             if (ModContent.GetInstance<ShieldModConfig>().ShowShieldText && !Main.dedServ)
-                CombatText.NewText(Player.Hitbox, Color.DodgerBlue, "-" + _queuedAbsorb);
+            {
+                Color hitColor = ModContent.GetInstance<ShieldModConfig>().ShieldHitColor;
+                CombatText.NewText(Player.Hitbox, hitColor, "-" + _queuedAbsorb);
+            }
 
             _queuedAbsorb = 0;
             _queuedStrong = false;

--- a/ShieldMod/ShieldMod.cs
+++ b/ShieldMod/ShieldMod.cs
@@ -76,7 +76,10 @@ namespace ShieldMod
                     {
                         Player p = Main.player[playerId];
                         if (p != null && p.active)
-                            CombatText.NewText(p.getRect(), Color.Cyan, $"+{healAmount}", true);
+                        {
+                            Color regenColor = ModContent.GetInstance<ShieldModConfig>().ShieldRegenColor;
+                            CombatText.NewText(p.getRect(), regenColor, $"+{healAmount}", true);
+                        }
                     }
                     break;
                 }

--- a/ShieldMod/ShieldModConfig.cs
+++ b/ShieldMod/ShieldModConfig.cs
@@ -1,5 +1,6 @@
-using Terraria.ModLoader.Config;
+using Microsoft.Xna.Framework;
 using System.ComponentModel;
+using Terraria.ModLoader.Config;
 
 namespace ShieldMod
 {
@@ -32,6 +33,16 @@ namespace ShieldMod
         [Tooltip("Displays your current shield regeneration tier (1/2/3/5/8/12/20 per second) or break cooldown as a small HUD label.")]
         [DefaultValue(true)]
         public bool ShowRegenCooldownIndicator;
+
+        [Label("Shield hit effect color")]
+        [Tooltip("Color used for the shield hit overlay and absorb text (default: blue).")]
+        [DefaultValue(typeof(Color), "30, 144, 255, 255")]
+        public Color ShieldHitColor { get; set; } = Color.DodgerBlue;
+
+        [Label("Shield regen effect color")]
+        [Tooltip("Color used for shield heal text effects.")]
+        [DefaultValue(typeof(Color), "0, 255, 255, 255")]
+        public Color ShieldRegenColor { get; set; } = Color.Cyan;
 
         [Label("Shield Max Health Ratio")]
         [Tooltip("Set the maximum shield as a percentage of the player's max health (statLifeMax2).\nExample: 1.00 = 100%, 0.25 = 25%")]


### PR DESCRIPTION
## Summary
- add client configuration options for shield hit and regen effect colors, with the hit numbers defaulting to blue
- apply the configurable colors to shield hit overlays, absorb text, and shield heal combat text (including network packet handling)
- add English localization entries for the new color settings

## Testing
- dotnet build ShieldMod.sln *(fails: dotnet CLI not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b51485bf8832da1c21493fc8d3c02)