### PR TITLE
Fix full-absorb i-frame persistence causing multiplayer invulnerability

### DIFF
--- a/ShieldMod/Players/ShieldPreAbsorbPlayer.cs
+++ b/ShieldMod/Players/ShieldPreAbsorbPlayer.cs
@@ -30,6 +30,7 @@ namespace ShieldMod
         // 완전 흡수 플래그 + 1데미지 생존 보정
         private bool _fullyAbsorbedFlag = false;
         private int _lifeBump = 0;
+        private int _fullAbsorbFrame = -1;
 
         public override void ModifyHurt(ref Player.HurtModifiers modifiers)
         {
@@ -81,6 +82,7 @@ namespace ShieldMod
                 {
                     // 완전 흡수: HP 데미지는 "없어야" 하므로 빨간 숫자 숨김
                     _fullyAbsorbedFlag = true;
+                    _fullAbsorbFrame = (int)Main.GameUpdateCount;
 
                     // 체력 1일 때 1데미지로 죽는 것 방지
                     if (Player.statLife <= 1)
@@ -193,7 +195,8 @@ if (_queuedBreak)
         public override void PostHurt(Player.HurtInfo info)
         {
             // 완전 흡수 시, 강제한 1데미지를 즉시 되돌려서 "실제 체력은 안 깎이게" 처리
-            if (_fullyAbsorbedFlag && info.Damage > 0)
+            if (_fullyAbsorbedFlag && info.Damage > 0
+                && Main.GameUpdateCount - _fullAbsorbFrame <= 1)
             {
                 // 1) HP 복구
                 Player.statLife = System.Math.Min(Player.statLifeMax2, Player.statLife + info.Damage);
@@ -210,6 +213,7 @@ if (_queuedBreak)
             }
 
             _fullyAbsorbedFlag = false;
+            _fullAbsorbFrame = -1;
         }
 
         private void EnforceShieldIFrames()


### PR DESCRIPTION
### Motivation
- Multiplayer could gain unintended invulnerability because the full-absorb flag was not tied to the game frame and could be processed later.
- The change ties restoration of the forced 1-damage HP bump and i-frame granting to the immediate frame to avoid stale restores.

### Description
- Added a private frame stamp field `int _fullAbsorbFrame` to `ShieldPreAbsorbPlayer.cs` and initialized it to `-1`.
- Set `_fullAbsorbFrame = (int)Main.GameUpdateCount` when a full absorb occurs in `ModifyHurt` alongside `_fullyAbsorbedFlag`.
- In `PostHurt`, require `Main.GameUpdateCount - _fullAbsorbFrame <= 1` before restoring HP and calling `EnforceShieldIFrames`, and reset `_fullAbsorbFrame` and `_fullyAbsorbedFlag` afterward.
- This limits the forced 1-damage reversal and i-frame enforcement to the immediate Hurt frame only.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dd049cdfc832d93dcb12e6389ba0a)