### PR TITLE
Make shield absorption server-authoritative and frame-bound full-absorb restore

### DIFF
--- a/ShieldMod/Players/ShieldPreAbsorbPlayer.cs
+++ b/ShieldMod/Players/ShieldPreAbsorbPlayer.cs
@@ -30,9 +30,13 @@ namespace ShieldMod
         // 완전 흡수 플래그 + 1데미지 생존 보정
         private bool _fullyAbsorbedFlag = false;
         private int _lifeBump = 0;
+        private int _fullAbsorbFrame = -1;
 
         public override void ModifyHurt(ref Player.HurtModifiers modifiers)
         {
+            if (Main.netMode == NetmodeID.MultiplayerClient)
+                return;
+
             var mp = Player.GetModPlayer<MyModPlayer>();
             if (mp == null || mp.shield <= 0) return;
 
@@ -81,6 +85,7 @@ namespace ShieldMod
                 {
                     // 완전 흡수: HP 데미지는 "없어야" 하므로 빨간 숫자 숨김
                     _fullyAbsorbedFlag = true;
+                    _fullAbsorbFrame = (int)Main.GameUpdateCount;
 
                     // 체력 1일 때 1데미지로 죽는 것 방지
                     if (Player.statLife <= 1)
@@ -104,6 +109,9 @@ namespace ShieldMod
                     // 부분 흡수(HP 데미지 있음): 빨간 숫자 정상 출력
                     // → HideCombatText / SuppressRedDamageText 건드리지 않음
                 }
+
+                if (Main.netMode == NetmodeID.Server)
+                    mp.NetSendShield(-1);
             };
         }
 
@@ -193,7 +201,8 @@ if (_queuedBreak)
         public override void PostHurt(Player.HurtInfo info)
         {
             // 완전 흡수 시, 강제한 1데미지를 즉시 되돌려서 "실제 체력은 안 깎이게" 처리
-            if (_fullyAbsorbedFlag && info.Damage > 0)
+            if (_fullyAbsorbedFlag && info.Damage > 0
+                && Main.GameUpdateCount - _fullAbsorbFrame <= 1)
             {
                 // 1) HP 복구
                 Player.statLife = System.Math.Min(Player.statLifeMax2, Player.statLife + info.Damage);
@@ -210,6 +219,7 @@ if (_queuedBreak)
             }
 
             _fullyAbsorbedFlag = false;
+            _fullAbsorbFrame = -1;
         }
 
         private void EnforceShieldIFrames()


### PR DESCRIPTION
### Motivation
- Prevent clients from applying shield absorption locally which can desynchronize state and cause unintended multiplayer invulnerability.
- Restrict the forced 1-damage HP bump and i-frame restoration for full-absorbs to the immediate Hurt frame to avoid stale restores.
- Ensure the server immediately synchronizes shield state to clients after an absorption.

### Description
- Skip client-side handling by returning early from `ModifyHurt` when `Main.netMode == NetmodeID.MultiplayerClient` so the server is authoritative for shield absorption.
- On the server path call `mp.NetSendShield(-1)` after absorption to immediately sync shield state to clients.
- Use `_fullAbsorbFrame` and a frame check (`Main.GameUpdateCount - _fullAbsorbFrame <= 1`) in `PostHurt` to limit HP restoration and `EnforceShieldIFrames` to the same frame, and reset the related flags.
- All changes are in `ShieldMod/Players/ShieldPreAbsorbPlayer.cs`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dd049cdfc832d93dcb12e6389ba0a)